### PR TITLE
Add an install routine that sets up iSparrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@
 
 # unignore source code and yaml files for config
 !src/**/*.py
-!tests/*.yaml
+!tests/*.yml
+!config/*.yml 
 !tests/*.py
 !pyproject.toml
+!setup.py
 
 #unignore documentation things 
 !**/*.rst

--- a/config/base_config.yml
+++ b/config/base_config.yml
@@ -1,0 +1,5 @@
+Directories: 
+  home: ~/iSparrow 
+  data: ~/iSparrow_data
+  models: ~/iSparrow/models 
+  output: ~/iSparrow_output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,35 +2,50 @@
 name = "iSparrow"
 version = "0.1"
 requires-python = ">= 3.10"
-authors=[{name = "Inga Ulusoy", email = "inga.ulusoy@uni-heidelberg.de"}, {name = "Harald Mack", email = "harald.mack@uni-heidelberg.de"}]
+authors = [
+    { name = "Inga Ulusoy", email = "inga.ulusoy@uni-heidelberg.de" },
+    { name = "Harald Mack", email = "harald.mack@uni-heidelberg.de" },
+]
 description = "Smart-IoT-based Passive bioAcoustic monitoRing of site-specific co-pResence of zOonotic Wildlife hosts and humans"
-readme ="README.md"
-license={file = "LICENSE"}
+readme = "README.md"
+license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache License",
 ]
-
 dependencies = [
-    "numpy", 
-    "librosa", 
-    "tensorflow", 
-    "torch", 
-    "torchaudio", 
-    "PyYAML", 
-    "scipy", 
-    "pandas", 
-    "birdnetlib==0.15.0", 
+    "numpy",
+    "librosa",
+    "tensorflow",
+    # "torch",
+    # "torchaudio",
+    "PyYAML",
+    # "scipy",
+    "pandas",
+    "birdnetlib==0.15.0",
+    "pooch",
 ]
 
+# docs = [] # TODO 
 
 [project.urls]
 Repository = "https://github.com/ssciwr/iSparrow"
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "setuptools-scm>7", "pooch", "PyYAML"]
 build-backend = "setuptools.build_meta"
 
 
-# add additional stuff when needed, poetry support? 
+# took this from https://github.com/ssciwr/organelle-morphology/blob/main/pyproject.toml
+# [tool.setuptools]
+# packages = ["src",]
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"
+write_to = "version.py"
+
+# The following is the configuration for the pytest test suite
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,237 @@
+from setuptools import setup
+from setuptools.command.install import install
+import pooch
+import shutil
+from pathlib import Path
+import yaml
+
+
+class InstallSparrow(install):
+    """
+    InstallSparrow Make folders and download the model files for classifying audio data.
+
+    """
+
+    def read_yaml(self, path: str):
+        print(f"...reaging config from {path}")
+        """
+        read_yaml Read the yaml basic config file for iSparrow from path.
+                It contains the install directory, data directory and other things used
+                by iSparrow internally.
+
+        Args:
+            path (str): Path to the yaml base config.
+
+        Returns:
+            dict: read base config file.
+        """
+
+        if Path(path).exists() is False:
+            raise FileNotFoundError(f"The folder {path} does not exist")
+
+        with open(Path(path) / Path("base_config.yml")) as file:
+            base_cfg = yaml.safe_load(file)
+
+        return base_cfg
+
+    def make_directories(self, base_cfg_dirs: dict):
+        """
+        make_directories _summary_
+
+
+        Args:
+            base_cfg_dirs (dict): _description_
+
+        Raises:
+            KeyError: A folder given in the config does not exist
+
+        Returns:
+            tuple: created folders: (isparrow-homefolder, modelsfolder, datafolder, outputfolder, examplefolder)
+        """
+        print("...Making direcotries...")
+        if "home" not in base_cfg_dirs:
+            raise KeyError(
+                "The home folder for iSparrow must be given in the base config"
+            )
+
+        if "models" not in base_cfg_dirs:
+            raise KeyError(
+                "The models folder for iSparrow must be given in the base config"
+            )
+
+        if "data" not in base_cfg_dirs:
+            raise KeyError(
+                "The data folder for iSparrow must be given in the base config"
+            )
+
+        if "output" not in base_cfg_dirs:
+            raise KeyError(
+                "The output folder for iSparrow must be given in the base config"
+            )
+
+
+
+        ish = Path(base_cfg_dirs["home"]).expanduser().resolve()
+        ism = Path(base_cfg_dirs["models"]).expanduser().resolve()
+        isd = Path(base_cfg_dirs["data"]).expanduser().resolve()
+        iso = Path(base_cfg_dirs["output"]).expanduser().resolve()
+        ise = (Path(base_cfg_dirs["home"]).expanduser() / Path("example")).resolve()
+
+        for p in [ish, ism, isd, iso, ise]:
+            p.mkdir(parents=True, exist_ok=True)
+
+        return ish, ism, isd, iso, ise
+
+    def download_model_files(self, isparrow_model_dir: str):
+        """
+        download_model_files Download models and class labels that iSparrow needs to analyze and classify audio data.
+
+        Args:
+            isparrow_homedir (str): Path to the main iSparrow directory
+        """
+
+        print("... Downloading model files...")
+
+        ism = Path(isparrow_model_dir)
+
+        if ism.exists() is False:
+            raise FileNotFoundError(f"The folder {isparrow_model_dir} does not exist")
+
+        # have filenames and checksum hardcoded for now. "None" indicates unknown or changing filenames
+        model_file_names = {
+            "birdnet_default_v2.4/model.tflite": "sha256:55f3e4055b1a13bfa9a2452731d0d34f6a02d6b775a334362665892794165e4c",
+            "birdnet_custom_v2.4/model.tflite": "sha256:5eee37652430c54490321e0d2096d55817b4ac4da2301b594f03fcb9d52af741",
+            "google_bird_classification/saved_model.pb": "sha256:c6bdf0c2659f6d4713c670b92cceb083f8c1b401aee79ef6912614a1d89b6f97",
+            "google_bird_classification/variables/variables.index": None,
+            "google_bird_classification/variables/variables.data-00000-of-00001": "sha256:d967ea7bfaccdcfe4ff59f8d9f3bdec69181e4e79fd7abebf692100efcdfcc56",
+        }
+
+        label_file_names = {
+            "birdnet_default_v2.4/labels.txt": None,
+            "birdnet_custom_v2.4/labels.txt": None,
+            "google_bird_classification/assets/family.csv": None,
+            "google_bird_classification/assets/genus.csv": None,
+            "google_bird_classification/assets/label.csv": None,
+            "google_bird_classification/assets/order.csv": None,
+        }
+
+        models_data = pooch.create(
+            path=pooch.os_cache("iSparrow"),
+            base_url="https://huggingface.co/MaHaWo/iSparrow_test_models/resolve/main",
+            registry=(model_file_names | label_file_names),
+        )
+
+        for name in ["model.tflite", "labels.txt"]:
+            shutil.copy(
+                Path(
+                    models_data.fetch(f"birdnet_default_v2.4/{name}", progressbar=False)
+                ),
+                ism / Path("default_birdnet"),
+            )
+
+        for name in ["model.tflite", "labels.txt"]:
+            shutil.copy(
+                Path(
+                    models_data.fetch(f"birdnet_custom_v2.4/{name}", progressbar=False)
+                ),
+                ism / Path("custom_birdnet"),
+            )
+
+        for name in ["model.tflite", "labels.txt"]:
+            shutil.copy(
+                Path(
+                    models_data.fetch(f"birdnet_custom_v2.4/{name}", progressbar=False)
+                ),
+                ism / Path("custom_birdnet"),
+            )
+
+        # don't leave them in the cached folder but copy to where user can actually see them.
+        for name in [
+            "saved_model.pb",
+            "variables/variables.index",
+            "variables/variables.data-00000-of-00001",
+            "assets/family.csv",
+            "assets/genus.csv",
+            "assets/label.csv",
+            "assets/order.csv",
+        ]:
+
+            shutil.copy(
+                Path(
+                    models_data.fetch(
+                        f"google_bird_classification/{name}", progressbar=False
+                    )
+                ),
+                ism / Path("google_perch"),
+            )
+
+    def download_example_data(self, isparrow_example_dir: str):
+        """
+        download_example_data Download the example audio files used by iSparrow for its tests and examples.
+
+        Args:
+            isparrow_homedir (str): Path to the main iSparrow directory
+        """
+
+        print("... Downloading example files...")
+
+        ise = Path(isparrow_example_dir)
+
+        if ise.exists() is False:
+            raise FileNotFoundError(f"The folder {isparrow_example_dir} does not exist")
+
+        # create registries to pull files from. haddcode names and hashes for now
+        example_data_file_names = {
+            "corrupted.wav": "sha256:68cbc7c63bed90c2ad4fb7d3b5cc608c82cebeaf5e91d5e8d6793d8645b30b95",
+            "soundscape.wav": "sha256:df312b45bc82ce4c638c3e9e09d748702ea14a91ec29e4e8e0676d3e3e015fd7",
+            "trimmed.wav": "sha256:a4b3c078d2c617264dc5e6a0d62deedba9232699580c9c73d237496726c194b3",
+        }
+
+        example_data = pooch.create(
+            path=pooch.os_cache("iSparrow"),
+            base_url="https://huggingface.co/datasets/MaHaWo/iSparrow_test_data/resolve/main",
+            registry=example_data_file_names,
+        )
+
+        # don't leave them in the cached folder but copy to where user can actually see them.
+        for name in example_data_file_names.keys():
+            shutil.copy(
+                Path(example_data.fetch(name, progressbar=False)),
+                ise,
+            )
+
+    def run(
+        self,
+    ):
+        """
+        install Install the necessary files and make the necessary folders for running iSparrow.
+
+        """
+        print("Creating iSparrow folders and downloading data... ")
+        # user cfg can override stuff that the base cfg has. When the two are merged, the result has
+        # the base_cfg values whereever user does not have anything
+
+        cfg_path = Path(__file__).resolve().parent / "config"
+
+        cfg = self.read_yaml(cfg_path)
+
+        home, models, data, output, examples = self.make_directories(
+            cfg["Directories"]
+        )
+
+        print(home, models, data, output, examples)
+
+        self.download_model_files(models.resolve())
+
+        self.download_example_data(examples.resolve())
+
+        print("Installation finished")
+
+
+setup(
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    cmdclass={
+        "install": InstallSparrow,
+    },
+)


### PR DESCRIPTION
The main task here is to set up a useful folder structure, download the [models]("https://huggingface.co/MaHaWo/iSparrow_test_models/resolve/main") and [example files]("https://huggingface.co/datasets/MaHaWo/iSparrow_test_data/resolve/main") and install the library as usual 

- [x] add rudimentary install configuration file that can be edited by the user
- [x] add `setup.py` with custom installer class that: 
    - [x]  reads the install config
    - [x]  creates all the specified folders therein 
    - [x] downloads the model files 
    - [ ] downloads the example files (needed for tests, but also in documentation later)
 
- [ ] make sure it installs correctly